### PR TITLE
Removing datasets not available in current OPD version. Closes #25

### DIFF
--- a/opd_download_page.py
+++ b/opd_download_page.py
@@ -1,5 +1,6 @@
 import streamlit as st
 import math
+from packaging import version
 import pandas as pd
 import logging
 
@@ -48,6 +49,10 @@ if 'last_selection' not in st.session_state:
 @st.cache_data
 def get_data_catalog():
     df = opd.datasets.query()
+    # Remove min_version = -1 (not available in any version) or min_version > current version
+    df = df[df["min_version"].apply(lambda x: 
+                                    pd.isnull(x) or (x.strip()!="-1" and version.parse(opd.__version__) >= version.parse(x))
+                                    )]
     df = df.sort_values(by=["State","SourceName","TableType"])
     return df
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 openpolicedata
+packaging
 pandas
 streamlit


### PR DESCRIPTION
Should remove where min_version is the last value in each row:
260  Illinois         Chicago         Chicago         Chicago Police Department  PEDESTRIAN STOPS     2019-01-01  ...  2019      CSV       <NA>       <NA>         <NA>          -1   
261  Illinois         Chicago         Chicago         Chicago Police Department  PEDESTRIAN STOPS     2020-01-01  ...  2020      CSV       <NA>       <NA>         <NA>          -1   
262  Illinois         Chicago         Chicago         Chicago Police Department  PEDESTRIAN STOPS     2021-01-01  ...  2021      CSV       <NA>       <NA>         <NA>          -1   
263  Illinois         Chicago         Chicago         Chicago Police Department  PEDESTRIAN STOPS     2022-01-01  ...  2022      CSV       <NA>       <NA>         <NA>          -1   
849  Virginia  Fairfax County  Fairfax County  Fairfax County Police Department  TRAFFIC WARNINGS     2022-01-01  ...  2022    Excel       <NA>       <NA>         <NA>       0.5.5   
